### PR TITLE
Add tpcgen CLI and Python package

### DIFF
--- a/.github/workflows/build-py-packages.yml
+++ b/.github/workflows/build-py-packages.yml
@@ -11,10 +11,13 @@ on:
 
 jobs:
   wheels:
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.build.runner }}
     strategy:
       matrix:
-        include:
+        package:
+          - tpchgen-cli
+          - tpcgen
+        build:
           # Linux manylinux
           - runner: ubuntu-22.04
             target: x86_64
@@ -76,19 +79,24 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.target }}
+          target: ${{ matrix.build.target }}
           args: --release --out dist
-          working-directory: tpchgen-cli
-          manylinux: ${{ matrix.manylinux || '' }}
+          working-directory: ${{ matrix.package }}
+          manylinux: ${{ matrix.build.manylinux || '' }}
       - name: Upload wheels
         if: ${{ inputs.upload-artifacts }}
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-${{ matrix.os }}-${{ matrix.target }}
-          path: tpchgen-cli/dist
+          name: wheels-${{ matrix.package }}-${{ matrix.build.os }}-${{ matrix.build.target }}
+          path: ${{ matrix.package }}/dist
 
   sdist:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package:
+          - tpchgen-cli
+          - tpcgen
     steps:
       - uses: actions/checkout@v7
       - name: Build sdist
@@ -96,10 +104,10 @@ jobs:
         with:
           command: sdist
           args: --out dist
-          working-directory: tpchgen-cli
+          working-directory: ${{ matrix.package }}
       - name: Upload sdist
         if: ${{ inputs.upload-artifacts }}
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-sdist
-          path: tpchgen-cli/dist
+          name: sdist-${{ matrix.package }}
+          path: ${{ matrix.package }}/dist

--- a/tpcgen/README.md
+++ b/tpcgen/README.md
@@ -1,0 +1,17 @@
+# TPC Data Generator CLI
+
+`tpcgen` is a command line interface for generating TPC benchmark data.
+
+## Install
+
+```shell
+pip install tpcgen
+```
+
+## Examples
+
+```shell
+tpcgen tpch -s 1 --output-dir /tmp/tpch
+tpcgen tpch parquet -s 100 --tables lineitem --parts 10 --output-dir /tmp/tpch
+tpcgen tpcds -s 1 --output-dir /tmp/tpcds
+```

--- a/tpcgen/pyproject.toml
+++ b/tpcgen/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "tpcgen"
+dynamic = ["version", "license", "authors"]
+description = "Python CLI for TPC data generator"
+readme = "README.md"
+requires-python = ">=3.8"
+
+[tool.maturin]
+bindings = "bin"
+manifest-path = "../tpchgen-cli/Cargo.toml"
+features = ["indicatif-progress", "bin-tpcgen"]
+no-default-features = true

--- a/tpchgen-cli/Cargo.toml
+++ b/tpchgen-cli/Cargo.toml
@@ -16,7 +16,12 @@ path = "src/lib.rs"
 [[bin]]
 name = "tpchgen-cli"
 path = "bin/tpchgen_cli.rs"
-required-features = ["indicatif-progress"]
+required-features = ["bin-tpchgen-cli", "indicatif-progress"]
+
+[[bin]]
+name = "tpcgen"
+path = "bin/tpcgen_cli.rs"
+required-features = ["bin-tpcgen", "indicatif-progress"]
 
 [dependencies]
 arrow = "59"
@@ -32,12 +37,14 @@ env_logger = "0.11.7"
 indicatif = { version = "0.18.3", optional = true }
 
 [features]
-default = ["indicatif-progress"]
+default = ["indicatif-progress", "bin-tpchgen-cli", "bin-tpcgen"]
 # Enable progress callbacks for applications that want to provide their own
 # progress reporting without pulling in the default terminal progress bars.
 progress = []
 # Enable the default CLI terminal progress bars backed by `indicatif`.
 indicatif-progress = ["progress", "dep:indicatif"]
+bin-tpchgen-cli = []
+bin-tpcgen = []
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/tpchgen-cli/bin/tpcds_cli.rs
+++ b/tpchgen-cli/bin/tpcds_cli.rs
@@ -1,0 +1,208 @@
+use clap::{ArgAction, Args, Subcommand};
+use std::path::PathBuf;
+use tpchgen_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Args)]
+#[command(version)]
+#[command(args_conflicts_with_subcommands = true)]
+pub(super) struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
+    #[command(flatten)]
+    args: DatArgs,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Generate DAT (pipe-delimited) output
+    Dat(DatArgs),
+    /// Generate CSV output with CSV-specific options
+    Csv(CsvArgs),
+    /// Generate Apache Parquet output with Parquet-specific options
+    Parquet(ParquetArgs),
+}
+
+#[derive(Args)]
+struct DatArgs {
+    #[command(flatten)]
+    common: CommonArgs,
+}
+
+#[derive(Args)]
+struct CsvArgs {
+    #[command(flatten)]
+    common: CommonArgs,
+
+    /// CSV delimiter character (default: ',')
+    ///
+    /// Specifies the delimiter character to use when generating CSV files.
+    ///
+    /// Supports escape sequences: \t (tab), \n (newline), \r (carriage return), \\ (backslash)
+    /// Common delimiters: ',' (comma), '|' (pipe), '\t' (tab), ';' (semicolon)
+    #[arg(long, default_value = ",", value_parser = parse_delimiter)]
+    delimiter: char,
+}
+
+#[derive(Args)]
+struct ParquetArgs {
+    #[command(flatten)]
+    common: CommonArgs,
+
+    /// Parquet block compression format.
+    ///
+    /// Supported values: UNCOMPRESSED, ZSTD(N), SNAPPY, GZIP, LZO, BROTLI, LZ4
+    ///
+    /// Note to use zstd you must supply the "compression" level (1-22)
+    /// as a number in parentheses, e.g. `ZSTD(1)` for level 1 compression.
+    ///
+    /// Using `ZSTD` results in the best compression, but is about 2x slower than
+    /// UNCOMPRESSED. For example, for the lineitem table at SF=10
+    ///
+    ///   ZSTD(1):      1.9G  (0.52 GB/sec)
+    ///   SNAPPY:       2.4G  (0.75 GB/sec)
+    ///   UNCOMPRESSED: 3.8G  (1.41 GB/sec)
+    #[arg(short = 'c', long, default_value = "SNAPPY")]
+    compression: Compression,
+
+    /// Target size in row group bytes in Parquet files
+    ///
+    /// Row groups are the typical unit of parallel processing and compression
+    /// with many query engines. Therefore, smaller row groups enable better
+    /// parallelism and lower peak memory use but may reduce compression
+    /// efficiency.
+    ///
+    /// Note: Parquet files are limited to 32k row groups, so at high scale
+    /// factors, the row group size may be increased to keep the number of row
+    /// groups under this limit.
+    ///
+    /// Typical values range from 10MB to 100MB.
+    #[arg(long, default_value_t = DEFAULT_PARQUET_ROW_GROUP_BYTES)]
+    row_group_bytes: i64,
+}
+
+#[derive(Args)]
+struct CommonArgs {
+    /// Scale factor to create
+    #[arg(short, long, default_value_t = 1.)]
+    scale_factor: f64,
+
+    /// Output directory for generated files (default: current directory)
+    #[arg(short, long, default_value = ".")]
+    output_dir: PathBuf,
+
+    /// Which tables to generate (default: all)
+    #[arg(short = 'T', long = "tables", value_delimiter = ',')]
+    tables: Option<Vec<String>>,
+
+    /// Number of part(itions) to generate. If not specified creates a single file per table
+    #[arg(short, long)]
+    parts: Option<i32>,
+
+    /// Which part(ition) to generate (1-based). If not specified, generates all parts
+    #[arg(long)]
+    part: Option<i32>,
+
+    /// The number of threads for parallel generation, defaults to the number of CPUs
+    #[arg(short, long, default_value_t = num_cpus::get())]
+    num_threads: usize,
+
+    /// Verbose output
+    ///
+    /// When specified, sets the log level to `info` and ignores the `RUST_LOG`
+    /// environment variable. When not specified, uses `RUST_LOG`
+    #[arg(short, long, default_value_t = false, conflicts_with = "quiet")]
+    verbose: bool,
+
+    /// Quiet mode - only show error-level logs
+    #[arg(short, long, default_value_t = false, conflicts_with = "verbose")]
+    quiet: bool,
+
+    /// Write the output to stdout instead of a file.
+    #[arg(long, default_value_t = false)]
+    stdout: bool,
+
+    /// Disable progress bars during data generation.
+    ///
+    /// Bars are also auto-suppressed by `--quiet`, `--stdout`, or when
+    /// stderr is not a terminal.
+    #[arg(long = "no-progress", action = ArgAction::SetFalse, default_value_t = true)]
+    progress_bars_enabled: bool,
+}
+
+impl Cli {
+    pub(super) fn run(self) -> Result<()> {
+        match self.command {
+            Some(Commands::Dat(args)) => args.run(),
+            Some(Commands::Csv(args)) => args.run(),
+            Some(Commands::Parquet(args)) => args.run(),
+            None => self.args.run(),
+        }
+    }
+}
+
+impl DatArgs {
+    fn run(self) -> Result<()> {
+        self.common.run()
+    }
+}
+
+impl CsvArgs {
+    fn run(self) -> Result<()> {
+        let _ = self.delimiter;
+        self.common.run()
+    }
+}
+
+impl ParquetArgs {
+    fn run(self) -> Result<()> {
+        let _ = (self.compression, self.row_group_bytes);
+        self.common.run()
+    }
+}
+
+impl CommonArgs {
+    fn run(self) -> Result<()> {
+        let _ = (
+            self.scale_factor,
+            self.output_dir,
+            self.tables,
+            self.parts,
+            self.part,
+            self.num_threads,
+            self.verbose,
+            self.quiet,
+            self.stdout,
+            self.progress_bars_enabled,
+        );
+        Ok(())
+    }
+}
+
+fn parse_delimiter(s: &str) -> std::result::Result<char, String> {
+    let parsed = match s {
+        "\\t" => '\t',
+        "\\n" => '\n',
+        "\\r" => '\r',
+        "\\\\" => '\\',
+        _ => {
+            let chars: Vec<char> = s.chars().collect();
+            if chars.len() != 1 {
+                return Err(format!(
+                    "Delimiter must be a single character or escape sequence (\\t, \\n, \\r, \\\\), got: '{}'",
+                    s
+                ));
+            }
+            chars[0]
+        }
+    };
+    if !parsed.is_ascii() {
+        return Err(format!(
+            "Delimiter must be an ASCII character, got: '{}'",
+            parsed
+        ));
+    }
+    Ok(parsed)
+}

--- a/tpchgen-cli/bin/tpcgen_cli.rs
+++ b/tpchgen-cli/bin/tpcgen_cli.rs
@@ -1,0 +1,69 @@
+use clap::{Parser, Subcommand};
+
+mod tpcds_cli;
+mod tpch_cli;
+
+use tpcds_cli::Cli as TpcdsCli;
+use tpch_cli::Cli as TpchCli;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Parser)]
+#[command(name = "tpcgen")]
+#[command(version)]
+#[command(
+    about = "TPC data generator",
+    long_about = r#"
+TPC data generator (https://github.com/clflushopt/tpchgen-rs)
+
+Examples
+
+# TPC-H TBL data:
+
+tpcgen tpch -s 1 --output-dir=/tmp/tpch
+
+# TPC-H CSV data:
+
+tpcgen tpch csv -s 1 --output-dir=/tmp/tpch
+
+# TPC-H Apache Parquet data:
+
+tpcgen tpch parquet -s 100 --tables=lineitem --parts=10 --output-dir=/tmp/tpch
+
+# TPC-DS DAT data:
+
+tpcgen tpcds -s 1 --output-dir=/tmp/tpcds
+
+# TPC-DS Apache Parquet data:
+
+tpcgen tpcds parquet -s 100 --tables=store_sales --output-dir=/tmp/tpcds
+"#
+)]
+struct TpcgenCli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// TPC-H data
+    Tpch(TpchCli),
+    /// TPC-DS data
+    Tpcds(TpcdsCli),
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    TpcgenCli::parse().run().await
+}
+
+impl TpcgenCli {
+    async fn run(self) -> Result<()> {
+        match self.command {
+            Command::Tpch(args) => args.main().await?,
+            Command::Tpcds(args) => args.run()?,
+        }
+
+        Ok(())
+    }
+}

--- a/tpchgen-cli/pyproject.toml
+++ b/tpchgen-cli/pyproject.toml
@@ -10,3 +10,5 @@ requires-python = ">=3.8"
 
 [tool.maturin]
 bindings = "bin"  # this makes maturin treat it as a binary crate (not a library)
+features = ["indicatif-progress", "bin-tpchgen-cli"]
+no-default-features = true

--- a/tpchgen-cli/tests/cli_integration.rs
+++ b/tpchgen-cli/tests/cli_integration.rs
@@ -1125,6 +1125,94 @@ async fn test_deprecated_parquet_compression_flag_works() {
     );
 }
 
+/// Test the TPC-H command forms for the `tpcgen` binary.
+#[test]
+fn test_tpcgen_tpch_command_forms() {
+    let forms: &[(&[&str], &[&str], &str)] = &[
+        (&["tpch"], &[], "part.tbl"),
+        (&["tpch", "tbl"], &[], "part.tbl"),
+        (&["tpch", "csv"], &["--delimiter", "|"], "part.csv"),
+        (
+            &["tpch", "parquet"],
+            &["--compression", "SNAPPY", "--row-group-bytes", "1000000"],
+            "part.parquet",
+        ),
+    ];
+
+    for (form, format_args, expected_file) in forms {
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+        cargo_bin_cmd!("tpcgen")
+            .args(*form)
+            .arg("--scale-factor")
+            .arg("0.001")
+            .arg("--tables")
+            .arg("part")
+            .arg("--output-dir")
+            .arg(temp_dir.path())
+            .arg("--no-progress")
+            .args(*format_args)
+            .assert()
+            .success();
+
+        let expected_file = temp_dir.path().join(expected_file);
+        assert!(
+            expected_file.exists(),
+            "Expected file {:?} to exist with `tpcgen {}`",
+            expected_file,
+            form.join(" ")
+        );
+    }
+}
+
+/// Test the TPC-DS command forms for the `tpcgen` binary.
+#[test]
+fn test_tpcgen_tpcds_command_forms() {
+    let forms: &[(&[&str], &[&str], &str)] = &[
+        (&["tpcds"], &[], "reason.dat"),
+        (&["tpcds", "dat"], &[], "reason.dat"),
+        (&["tpcds", "csv"], &["--delimiter", "|"], "reason.csv"),
+        (
+            &["tpcds", "parquet"],
+            &["--compression", "SNAPPY", "--row-group-bytes", "1000000"],
+            "reason.parquet",
+        ),
+    ];
+
+    for (form, format_args, expected_file) in forms {
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+        cargo_bin_cmd!("tpcgen")
+            .args(*form)
+            .arg("--scale-factor")
+            .arg("1")
+            .arg("--tables")
+            .arg("reason")
+            .arg("--output-dir")
+            .arg(temp_dir.path())
+            .arg("--parts")
+            .arg("2")
+            .arg("--part")
+            .arg("1")
+            .arg("--num-threads")
+            .arg("1")
+            .arg("--stdout")
+            .arg("--quiet")
+            .arg("--no-progress")
+            .args(*format_args)
+            .assert()
+            .success();
+
+        let expected_file = temp_dir.path().join(expected_file);
+        assert!(
+            !expected_file.exists(),
+            "Expected `tpcgen {}` not to create {:?}",
+            form.join(" "),
+            expected_file
+        );
+    }
+}
+
 /// Test that deprecated --format=parquet with --parquet-row-group-bytes still works
 #[tokio::test]
 async fn test_deprecated_parquet_row_group_bytes_flag_works() {


### PR DESCRIPTION
Builds on clflushopt/tpchgen-rs#279. Adds the Rust tpcgen binary, wires tpcgen tpch to reuse the existing TPC-H CLI implementation, adds the initial TPC-DS CLI surface, and adds a separate Python tpcgen package so the existing tpchgen-cli package continues to ship only tpchgen-cli. Validated with cargo fmt, cargo check, cargo test, maturin build/sdist for both Python packages, and fresh wheel installs for both binaries.