### PR TITLE
Add tpcgen CLI and Python package

### DIFF
--- a/.github/workflows/build-py-packages.yml
+++ b/.github/workflows/build-py-packages.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: false
         type: boolean
+      package:
+        description: "Package to build: all, tpchgen-cli, or tpcgen"
+        required: false
+        default: all
+        type: string
 
 jobs:
   wheels:
@@ -73,33 +78,62 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - name: Build wheels
+      - name: Build tpchgen-cli wheel
+        if: ${{ inputs.package == 'all' || inputs.package == 'tpchgen-cli' }}
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           args: --release --out dist
           working-directory: tpchgen-cli
           manylinux: ${{ matrix.manylinux || '' }}
-      - name: Upload wheels
-        if: ${{ inputs.upload-artifacts }}
+      - name: Build tpcgen wheel
+        if: ${{ inputs.package == 'all' || inputs.package == 'tpcgen' }}
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          working-directory: tpcgen
+          manylinux: ${{ matrix.manylinux || '' }}
+      - name: Upload tpchgen-cli wheels
+        if: ${{ inputs.upload-artifacts && (inputs.package == 'all' || inputs.package == 'tpchgen-cli') }}
         uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.target }}
           path: tpchgen-cli/dist
+      - name: Upload tpcgen wheels
+        if: ${{ inputs.upload-artifacts && (inputs.package == 'all' || inputs.package == 'tpcgen') }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels-tpcgen-${{ matrix.os }}-${{ matrix.target }}
+          path: tpcgen/dist
 
   sdist:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Build sdist
+      - name: Build tpchgen-cli sdist
+        if: ${{ inputs.package == 'all' || inputs.package == 'tpchgen-cli' }}
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
           args: --out dist
           working-directory: tpchgen-cli
-      - name: Upload sdist
-        if: ${{ inputs.upload-artifacts }}
+      - name: Build tpcgen sdist
+        if: ${{ inputs.package == 'all' || inputs.package == 'tpcgen' }}
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+          working-directory: tpcgen
+      - name: Upload tpchgen-cli sdist
+        if: ${{ inputs.upload-artifacts && (inputs.package == 'all' || inputs.package == 'tpchgen-cli') }}
         uses: actions/upload-artifact@v7
         with:
           name: wheels-sdist
           path: tpchgen-cli/dist
+      - name: Upload tpcgen sdist
+        if: ${{ inputs.upload-artifacts && (inputs.package == 'all' || inputs.package == 'tpcgen') }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: sdist-tpcgen
+          path: tpcgen/dist

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,6 +61,15 @@ jobs:
       - name: All Tests (tpchgen-cli)
         run: cargo test -p tpchgen-cli
 
+  # All tests for tpcgen
+  test-all-tpcgen:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v7
+      - name: All Tests (tpcgen)
+        run: cargo test -p tpcgen
+
   # All tests for tpcdsgen
   test-all-tpcdsgen:
     runs-on: ubuntu-latest

--- a/.github/workflows/tpcgen-publish-pypi.yml
+++ b/.github/workflows/tpcgen-publish-pypi.yml
@@ -1,4 +1,4 @@
-name: tpchgen-cli-publish-pypi
+name: tpcgen-publish-pypi
 
 on:
   release:
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/build-py-packages.yml
     with:
       upload-artifacts: true
-      package: tpchgen-cli
+      package: tpcgen
 
   release:
     name: Release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 
-members = [ "tpchgen", "tpcdsgen" , "tpchgen-arrow", "tpchgen-cli"]
+members = [ "tpchgen", "tpcdsgen" , "tpchgen-arrow", "tpchgen-cli", "tpcgen"]
 
 resolver = "2"
 

--- a/tpcgen/Cargo.toml
+++ b/tpcgen/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tpcgen"
+version = "0.1.0"
+authors = { workspace = true }
+description = "Command line tool for TPC benchmark data generation."
+readme = "README.md"
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+name = "tpcgen"
+path = "src/lib.rs"
+
+[[bin]]
+name = "tpcgen"
+path = "bin/tpcgen.rs"
+
+[dependencies]
+clap = { version = "4.5.32", features = ["derive"] }
+tokio = { version = "1.44.1", features = ["full"] }
+tpchgen-cli = { path = "../tpchgen-cli", version = "2.0.2", default-features = false, features = ["indicatif-progress"] }
+
+[dev-dependencies]
+assert_cmd = "2.0"
+tempfile = "3.20.0"

--- a/tpcgen/README.md
+++ b/tpcgen/README.md
@@ -1,0 +1,17 @@
+# TPC Data Generator CLI
+
+`tpcgen` is a command line interface for generating TPC-H and TPC-DS benchmark data.
+
+## Install
+
+```shell
+pip install tpcgen
+```
+
+## Examples
+
+```shell
+tpcgen tpch -s 1 --output-dir /tmp/tpch
+tpcgen tpch csv -s 1 --output-dir /tmp/tpch
+tpcgen tpch parquet -s 100 --tables lineitem --parts 10 --output-dir /tmp/tpch
+```

--- a/tpcgen/bin/tpcgen.rs
+++ b/tpcgen/bin/tpcgen.rs
@@ -1,0 +1,9 @@
+use clap::Parser;
+use tpcgen::tpcgen_cli::Cli;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    Cli::parse().run().await
+}

--- a/tpcgen/pyproject.toml
+++ b/tpcgen/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "tpcgen"
+dynamic = ["version", "readme", "license", "authors"]
+description = "Python CLI for TPC-H and TPC-DS data generation"
+requires-python = ">=3.8"
+
+[tool.maturin]
+bindings = "bin"

--- a/tpcgen/src/lib.rs
+++ b/tpcgen/src/lib.rs
@@ -1,0 +1,3 @@
+mod tpcds_cli;
+
+pub mod tpcgen_cli;

--- a/tpcgen/src/tpcds_cli.rs
+++ b/tpcgen/src/tpcds_cli.rs
@@ -1,8 +1,10 @@
 use clap::{ArgAction, Args, Subcommand};
+use std::fmt;
 use std::path::PathBuf;
 use tpchgen_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+const NOT_IMPLEMENTED: &str = "TPC-DS data generation is not yet implemented";
 
 #[derive(Args)]
 #[command(version)]
@@ -156,9 +158,25 @@ impl CommonArgs {
             self.quiet,
             self.progress_bars_enabled,
         );
-        Ok(())
+        Err(Box::new(NotImplemented))
     }
 }
+
+struct NotImplemented;
+
+impl fmt::Display for NotImplemented {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(NOT_IMPLEMENTED)
+    }
+}
+
+impl fmt::Debug for NotImplemented {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl std::error::Error for NotImplemented {}
 
 fn parse_delimiter(s: &str) -> std::result::Result<char, String> {
     let parsed = match s {

--- a/tpcgen/src/tpcds_cli.rs
+++ b/tpcgen/src/tpcds_cli.rs
@@ -1,0 +1,187 @@
+use clap::{ArgAction, Args, Subcommand};
+use std::path::PathBuf;
+use tpchgen_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Args)]
+#[command(version)]
+#[command(args_conflicts_with_subcommands = true)]
+pub(crate) struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
+    #[command(flatten)]
+    args: DatArgs,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Generate DAT (pipe-delimited) output
+    Dat(DatArgs),
+    /// Generate CSV output with CSV-specific options
+    Csv(CsvArgs),
+    /// Generate Apache Parquet output with Parquet-specific options
+    Parquet(ParquetArgs),
+}
+
+#[derive(Args)]
+struct DatArgs {
+    #[command(flatten)]
+    common: CommonArgs,
+}
+
+#[derive(Args)]
+struct CsvArgs {
+    #[command(flatten)]
+    common: CommonArgs,
+
+    /// CSV delimiter character (default: ',')
+    ///
+    /// Specifies the delimiter character to use when generating CSV files.
+    ///
+    /// Supports escape sequences: \t (tab), \n (newline), \r (carriage return), \\ (backslash)
+    /// Common delimiters: ',' (comma), '|' (pipe), '\t' (tab), ';' (semicolon)
+    #[arg(long, default_value = ",", value_parser = parse_delimiter)]
+    delimiter: char,
+}
+
+#[derive(Args)]
+struct ParquetArgs {
+    #[command(flatten)]
+    common: CommonArgs,
+
+    /// Parquet block compression format.
+    ///
+    /// Supported values: UNCOMPRESSED, ZSTD(N), SNAPPY, GZIP, LZO, BROTLI, LZ4
+    ///
+    /// Note to use zstd you must supply the "compression" level (1-22)
+    /// as a number in parentheses, e.g. `ZSTD(1)` for level 1 compression.
+    ///
+    /// Using `ZSTD` results in the best compression, but is about 2x slower than
+    /// UNCOMPRESSED. For example, for the lineitem table at SF=10
+    ///
+    ///   ZSTD(1):      1.9G  (0.52 GB/sec)
+    ///   SNAPPY:       2.4G  (0.75 GB/sec)
+    ///   UNCOMPRESSED: 3.8G  (1.41 GB/sec)
+    #[arg(short = 'c', long, default_value = "SNAPPY")]
+    compression: Compression,
+
+    /// Target size in row group bytes in Parquet files
+    ///
+    /// Row groups are the typical unit of parallel processing and compression
+    /// with many query engines. Therefore, smaller row groups enable better
+    /// parallelism and lower peak memory use but may reduce compression
+    /// efficiency.
+    ///
+    /// Note: Parquet files are limited to 32k row groups, so at high scale
+    /// factors, the row group size may be increased to keep the number of row
+    /// groups under this limit.
+    ///
+    /// Typical values range from 10MB to 100MB.
+    #[arg(long, default_value_t = DEFAULT_PARQUET_ROW_GROUP_BYTES)]
+    row_group_bytes: i64,
+}
+
+#[derive(Args)]
+struct CommonArgs {
+    /// Scale factor to create
+    #[arg(short, long, default_value_t = 1.)]
+    scale_factor: f64,
+
+    /// Output directory for generated files (default: current directory)
+    #[arg(short, long, default_value = ".")]
+    output_dir: PathBuf,
+
+    /// Which tables to generate (default: all)
+    #[arg(short = 'T', long = "tables", value_delimiter = ',')]
+    tables: Option<Vec<String>>,
+
+    /// Verbose output
+    ///
+    /// When specified, sets the log level to `info` and ignores the `RUST_LOG`
+    /// environment variable. When not specified, uses `RUST_LOG`
+    #[arg(short, long, default_value_t = false, conflicts_with = "quiet")]
+    verbose: bool,
+
+    /// Quiet mode - only show error-level logs
+    #[arg(short, long, default_value_t = false, conflicts_with = "verbose")]
+    quiet: bool,
+
+    /// Disable progress bars during data generation.
+    ///
+    /// Bars are also auto-suppressed by `--quiet` or when stderr is not a terminal.
+    #[arg(long = "no-progress", action = ArgAction::SetFalse, default_value_t = true)]
+    progress_bars_enabled: bool,
+}
+
+impl Cli {
+    pub(crate) fn run(self) -> Result<()> {
+        match self.command {
+            Some(Commands::Dat(args)) => args.run(),
+            Some(Commands::Csv(args)) => args.run(),
+            Some(Commands::Parquet(args)) => args.run(),
+            None => self.args.run(),
+        }
+    }
+}
+
+impl DatArgs {
+    fn run(self) -> Result<()> {
+        self.common.run()
+    }
+}
+
+impl CsvArgs {
+    fn run(self) -> Result<()> {
+        let _ = self.delimiter;
+        self.common.run()
+    }
+}
+
+impl ParquetArgs {
+    fn run(self) -> Result<()> {
+        let _ = (self.compression, self.row_group_bytes);
+        self.common.run()
+    }
+}
+
+impl CommonArgs {
+    fn run(self) -> Result<()> {
+        let _ = (
+            self.scale_factor,
+            self.output_dir,
+            self.tables,
+            self.verbose,
+            self.quiet,
+            self.progress_bars_enabled,
+        );
+        Ok(())
+    }
+}
+
+fn parse_delimiter(s: &str) -> std::result::Result<char, String> {
+    let parsed = match s {
+        "\\t" => '\t',
+        "\\n" => '\n',
+        "\\r" => '\r',
+        "\\\\" => '\\',
+        _ => {
+            let chars: Vec<char> = s.chars().collect();
+            if chars.len() != 1 {
+                return Err(format!(
+                    "Delimiter must be a single character or escape sequence (\\t, \\n, \\r, \\\\), got: '{}'",
+                    s
+                ));
+            }
+            chars[0]
+        }
+    };
+    if !parsed.is_ascii() {
+        return Err(format!(
+            "Delimiter must be an ASCII character, got: '{}'",
+            parsed
+        ));
+    }
+    Ok(parsed)
+}

--- a/tpcgen/src/tpcgen_cli.rs
+++ b/tpcgen/src/tpcgen_cli.rs
@@ -1,0 +1,53 @@
+use clap::{Parser, Subcommand};
+
+use crate::tpcds_cli::Cli as TpcdsCli;
+use tpchgen_cli::tpch_cli::Cli as TpchCli;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Parser)]
+#[command(name = "tpcgen")]
+#[command(version)]
+#[command(
+    about = "TPC-H and TPC-DS data generator",
+    long_about = r#"
+TPC-H and TPC-DS data generator (https://github.com/clflushopt/tpchgen-rs)
+
+Examples
+
+# TPC-H TBL data:
+
+tpcgen tpch -s 1 --output-dir=/tmp/tpch
+
+# TPC-H CSV data:
+
+tpcgen tpch csv -s 1 --output-dir=/tmp/tpch
+
+# TPC-H Apache Parquet data:
+
+tpcgen tpch parquet -s 100 --tables=lineitem --parts=10 --output-dir=/tmp/tpch
+"#
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// TPC-H data
+    Tpch(TpchCli),
+    /// TPC-DS data
+    Tpcds(TpcdsCli),
+}
+
+impl Cli {
+    pub async fn run(self) -> Result<()> {
+        match self.command {
+            Command::Tpch(args) => args.run().await?,
+            Command::Tpcds(args) => args.run()?,
+        }
+
+        Ok(())
+    }
+}

--- a/tpcgen/tests/cli_integration.rs
+++ b/tpcgen/tests/cli_integration.rs
@@ -41,9 +41,9 @@ fn test_tpcgen_tpch_command_forms() {
     }
 }
 
-/// Test the TPC-DS command forms currently parse but do not write output.
+/// Test the TPC-DS command forms parse and report that generation is unavailable.
 #[test]
-fn test_tpcgen_tpcds_command_forms_are_noops() {
+fn test_tpcgen_tpcds_command_forms_are_not_implemented() {
     let forms: &[(&[&str], &[&str], &str)] = &[
         (&["tpcds"], &[], "reason.dat"),
         (&["tpcds", "dat"], &[], "reason.dat"),
@@ -58,7 +58,7 @@ fn test_tpcgen_tpcds_command_forms_are_noops() {
     for (form, format_args, unexpected_file) in forms {
         let temp_dir = tempdir().expect("Failed to create temporary directory");
 
-        cargo_bin_cmd!("tpcgen")
+        let assert = cargo_bin_cmd!("tpcgen")
             .args(*form)
             .arg("--scale-factor")
             .arg("1")
@@ -70,7 +70,15 @@ fn test_tpcgen_tpcds_command_forms_are_noops() {
             .arg("--no-progress")
             .args(*format_args)
             .assert()
-            .success();
+            .failure();
+
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        assert!(
+            stderr.contains("TPC-DS data generation is not yet implemented"),
+            "Expected `tpcgen {}` to report that TPC-DS generation is not implemented, got stderr: {}",
+            form.join(" "),
+            stderr
+        );
 
         let unexpected_file = temp_dir.path().join(unexpected_file);
         assert!(

--- a/tpcgen/tests/cli_integration.rs
+++ b/tpcgen/tests/cli_integration.rs
@@ -1,0 +1,83 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use tempfile::tempdir;
+
+/// Test the TPC-H command forms for the `tpcgen` binary.
+#[test]
+fn test_tpcgen_tpch_command_forms() {
+    let forms: &[(&[&str], &[&str], &str)] = &[
+        (&["tpch"], &[], "part.tbl"),
+        (&["tpch", "tbl"], &[], "part.tbl"),
+        (&["tpch", "csv"], &["--delimiter", "|"], "part.csv"),
+        (
+            &["tpch", "parquet"],
+            &["--compression", "SNAPPY", "--row-group-bytes", "1000000"],
+            "part.parquet",
+        ),
+    ];
+
+    for (form, format_args, expected_file) in forms {
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+        cargo_bin_cmd!("tpcgen")
+            .args(*form)
+            .arg("--scale-factor")
+            .arg("0.001")
+            .arg("--tables")
+            .arg("part")
+            .arg("--output-dir")
+            .arg(temp_dir.path())
+            .arg("--no-progress")
+            .args(*format_args)
+            .assert()
+            .success();
+
+        let expected_file = temp_dir.path().join(expected_file);
+        assert!(
+            expected_file.exists(),
+            "Expected file {:?} to exist with `tpcgen {}`",
+            expected_file,
+            form.join(" ")
+        );
+    }
+}
+
+/// Test the TPC-DS command forms currently parse but do not write output.
+#[test]
+fn test_tpcgen_tpcds_command_forms_are_noops() {
+    let forms: &[(&[&str], &[&str], &str)] = &[
+        (&["tpcds"], &[], "reason.dat"),
+        (&["tpcds", "dat"], &[], "reason.dat"),
+        (&["tpcds", "csv"], &["--delimiter", "|"], "reason.csv"),
+        (
+            &["tpcds", "parquet"],
+            &["--compression", "SNAPPY", "--row-group-bytes", "1000000"],
+            "reason.parquet",
+        ),
+    ];
+
+    for (form, format_args, unexpected_file) in forms {
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+        cargo_bin_cmd!("tpcgen")
+            .args(*form)
+            .arg("--scale-factor")
+            .arg("1")
+            .arg("--tables")
+            .arg("reason")
+            .arg("--output-dir")
+            .arg(temp_dir.path())
+            .arg("--quiet")
+            .arg("--no-progress")
+            .args(*format_args)
+            .assert()
+            .success();
+
+        let unexpected_file = temp_dir.path().join(unexpected_file);
+        assert!(
+            !unexpected_file.exists(),
+            "Expected `tpcgen {}` not to create {:?}",
+            form.join(" "),
+            unexpected_file
+        );
+    }
+}

--- a/tpchgen-cli/Cargo.toml
+++ b/tpchgen-cli/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 
 [[bin]]
 name = "tpchgen-cli"
-path = "bin/main.rs"
+path = "bin/tpchgen_cli.rs"
 required-features = ["indicatif-progress"]
 
 [dependencies]

--- a/tpchgen-cli/bin/tpchgen_cli.rs
+++ b/tpchgen-cli/bin/tpchgen_cli.rs
@@ -1,0 +1,8 @@
+use clap::Parser;
+use std::io;
+use tpchgen_cli::tpch_cli::Cli;
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    Cli::parse().run().await
+}

--- a/tpchgen-cli/src/lib.rs
+++ b/tpchgen-cli/src/lib.rs
@@ -38,6 +38,8 @@ pub mod progress;
 pub mod runner;
 pub mod statistics;
 pub mod tbl;
+#[cfg(feature = "indicatif-progress")]
+pub mod tpch_cli;
 
 use crate::generate::Sink;
 use crate::parquet::IntoSize;

--- a/tpchgen-cli/src/tpch_cli.rs
+++ b/tpchgen-cli/src/tpch_cli.rs
@@ -7,6 +7,11 @@
 //! See the documentation on [`Cli`] for more information on the command line
 
 // Use the library public API
+use crate::progress::IndicatifProgress;
+use crate::{
+    Compression, OutputFormat, Table, TpchGenerator, TpchGeneratorBuilder,
+    DEFAULT_PARQUET_ROW_GROUP_BYTES,
+};
 use clap::builder::TypedValueParser;
 use clap::{ArgAction, Parser};
 use log::{info, LevelFilter};
@@ -14,11 +19,6 @@ use std::io::{self, IsTerminal};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
-use tpchgen_cli::progress::IndicatifProgress;
-use tpchgen_cli::{
-    Compression, OutputFormat, Table, TpchGenerator, TpchGeneratorBuilder,
-    DEFAULT_PARQUET_ROW_GROUP_BYTES,
-};
 
 #[derive(Parser)]
 #[command(name = "tpchgen")]
@@ -60,7 +60,7 @@ RUST_LOG=debug tpchgen-cli -s 1 --output-dir=/tmp/tpch
 "#,
     args_conflicts_with_subcommands = true
 )]
-struct Cli {
+pub struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
 
@@ -325,25 +325,18 @@ impl TypedValueParser for TableValueParser {
     }
 }
 
-#[tokio::main]
-async fn main() -> io::Result<()> {
-    // Parse command line arguments
-    let cli = Cli::parse();
-    cli.main().await
-}
-
 impl Cli {
-    /// Main function to run the generation
-    async fn main(self) -> io::Result<()> {
+    /// Run data generation for the selected command.
+    pub async fn run(self) -> io::Result<()> {
         match self.command {
             Some(Commands::Tbl(args)) => args.run().await,
             Some(Commands::Csv(args)) => args.run().await,
             Some(Commands::Parquet(args)) => args.run().await,
-            None => self.run().await,
+            None => self.run_default().await,
         }
     }
 
-    async fn run(self) -> io::Result<()> {
+    async fn run_default(self) -> io::Result<()> {
         // Warn about --format migration to subcommands (only when explicitly provided)
         let (format, subcommand) = if let Some(format) = self.args.format {
             let subcommand = match format {


### PR DESCRIPTION
## Summary

This PR introduces a new `tpcgen` CLI and Python package while keeping the existing `tpchgen-cli` binary and package behavior intact.

The major themes are refactoring the existing TPC-H CLI into a reusable module, adding the Rust `tpcgen` command hierarchy, and wiring the new Python package into CI and release workflows.

## Changes

- Refactor the existing `tpchgen-cli` entrypoint into a reusable `tpch_cli` module
- Keep `tpchgen-cli` as a thin wrapper around the TPC-H CLI implementation
- Add a new `tpcgen` Rust crate and binary
- Reuse the existing TPC-H parser/runner for `tpcgen tpch`
- Add the initial TPC-DS CLI command surface for `dat`, `csv`, and `parquet`
- Return a clear `TPC-DS data generation is not yet implemented` error for `tpcgen tpcds` commands
- Add integration tests for the new `tpcgen` command forms
- Add a new `tpcgen` Python package
- Update CI to build and test `tpcgen`
- Update Python package build and publish workflows for both `tpchgen-cli` and `tpcgen`

## Review Notes

The commits are structured step-wise:

1. Refactor `tpchgen-cli` into a reusable TPC-H CLI module
2. Add the Rust `tpcgen` CLI package
3. Add the `tpcgen` Python package and package workflow updates
4. Report TPC-DS generation as not yet implemented

TPC-DS CLI commands parse successfully, then exit with a clear not-yet-implemented error instead of silently doing nothing. TPC-DS generation can be added in follow-up work.

## Validation

- `cargo fmt --all -- --check`
- `actionlint .github/workflows/build-py-packages.yml .github/workflows/tpchgen-cli-publish-pypi.yml .github/workflows/tpcgen-publish-pypi.yml .github/workflows/rust.yml`
- `cargo check --workspace --all-targets`
- `cargo test -p tpcgen -- --nocapture`
- `cargo test -p tpchgen-cli`
- `cargo clippy -- -D warnings`
- `target/release/tpcgen tpcds -s 1 --output-dir /tmp/tpcds --quiet`
