### PR TITLE
Add TPC-DS progress tracking to tpcgen

### DIFF
--- a/tpcdsgen/Cargo.toml
+++ b/tpcdsgen/Cargo.toml
@@ -12,6 +12,15 @@ homepage = { workspace = true }
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 chrono = "0.4"
+indicatif = { version = "0.18.3", optional = true }
+
+[features]
+default = []
+progress = []
+indicatif-progress = ["progress", "dep:indicatif"]
+
+[dev-dependencies]
+tempfile = "3.20.0"
 
 [[bin]]
 name = "tpcdsgen"

--- a/tpcdsgen/src/dat.rs
+++ b/tpcdsgen/src/dat.rs
@@ -12,40 +12,36 @@
  * limitations under the License.
  */
 
-//! TPC-DS Data Generator - Rust Implementation
-//!
-//! Generates TPC-DS benchmark data with byte-for-byte compatibility with the Java reference.
+//! TPC-DS DAT output generation.
 
-use clap::Parser;
-use std::fs::File;
+use std::fs::{create_dir_all, File};
 use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::time::Instant;
 
-use tpcdsgen::config::{Options, Session, Table};
-use tpcdsgen::output::CompatWriter;
-use tpcdsgen::row::*;
-use tpcdsgen::types::Date;
+use crate::config::{Session, Table};
+use crate::output::CompatWriter;
+use crate::row::*;
+use crate::types::Date;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-fn main() -> Result<()> {
-    let options = Options::parse();
-    let session = options.to_session()?;
-
+/// Generate TPC-DS data in DAT format.
+pub fn generate(session: &Session) -> Result<()> {
     println!("TPC-DS Data Generator (Rust)");
     println!("Scale factor: {}", session.get_scaling().get_scale());
     println!("Output directory: {}", session.get_target_directory());
+
+    create_dir_all(session.get_target_directory())?;
 
     let start = Instant::now();
 
     if session.generate_only_one_table() {
         let table = session.get_only_table_to_generate();
-        generate_table(table, &session)?;
+        generate_table(table, session)?;
     } else {
-        // Generate all main tables
         for table in Table::main_tables() {
-            generate_table(table, &session)?;
+            generate_table(table, session)?;
         }
     }
 
@@ -332,8 +328,8 @@ fn generate_inventory(session: &Session) -> Result<()> {
     let mut generator = InventoryRowGenerator::new();
     let scaling = session.get_scaling();
 
-    let item_count = scaling.get_id_count(tpcdsgen::config::Table::Item);
-    let warehouse_count = scaling.get_row_count(tpcdsgen::config::Table::Warehouse);
+    let item_count = scaling.get_id_count(Table::Item);
+    let warehouse_count = scaling.get_row_count(Table::Warehouse);
     let n_days = Date::JULIAN_DATE_MAXIMUM - Date::JULIAN_DATE_MINIMUM;
     let n_weeks = (n_days + 7) / 7;
     let num_rows = item_count * warehouse_count * n_weeks as i64;

--- a/tpcdsgen/src/dat.rs
+++ b/tpcdsgen/src/dat.rs
@@ -21,29 +21,68 @@ use std::time::Instant;
 
 use crate::config::{Session, Table};
 use crate::output::CompatWriter;
+#[cfg(feature = "progress")]
+use crate::progress::ProgressTracker;
+use crate::progress::RunProgress;
 use crate::row::*;
-use crate::types::Date;
+#[cfg(feature = "progress")]
+use std::sync::Arc;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 /// Generate TPC-DS data in DAT format.
 pub fn generate(session: &Session) -> Result<()> {
+    let tables = tables_for_session(session);
+    generate_tables_inner(session, tables, RunProgress::default())
+}
+
+/// Generate the specified TPC-DS tables in DAT format.
+pub fn generate_tables(session: &Session, tables: &[Table]) -> Result<()> {
+    generate_tables_inner(session, tables.to_vec(), RunProgress::default())
+}
+
+/// Generate TPC-DS data in DAT format with progress tracking.
+#[cfg(feature = "progress")]
+pub fn generate_with_progress(session: &Session, progress: Arc<dyn ProgressTracker>) -> Result<()> {
+    let tables = tables_for_session(session);
+    generate_tables_inner(session, tables, RunProgress::with_tracker(progress))
+}
+
+/// Generate the specified TPC-DS tables in DAT format with progress tracking.
+#[cfg(feature = "progress")]
+pub fn generate_tables_with_progress(
+    session: &Session,
+    tables: &[Table],
+    progress: Arc<dyn ProgressTracker>,
+) -> Result<()> {
+    generate_tables_inner(
+        session,
+        tables.to_vec(),
+        RunProgress::with_tracker(progress),
+    )
+}
+
+fn generate_tables_inner(
+    session: &Session,
+    tables: Vec<Table>,
+    progress: RunProgress,
+) -> Result<()> {
     println!("TPC-DS Data Generator (Rust)");
     println!("Scale factor: {}", session.get_scaling().get_scale());
     println!("Output directory: {}", session.get_target_directory());
 
     create_dir_all(session.get_target_directory())?;
 
+    let tables = dat_output_tables(tables);
     let start = Instant::now();
+    let totals = progress_totals(&tables, session);
+    progress.register_totals(&totals);
 
-    if session.generate_only_one_table() {
-        let table = session.get_only_table_to_generate();
-        generate_table(table, session)?;
-    } else {
-        for table in Table::main_tables() {
-            generate_table(table, session)?;
-        }
+    for table in tables {
+        generate_table(table, session, &progress)?;
     }
+
+    progress.finish();
 
     let elapsed = start.elapsed();
     println!("\nCompleted in {:.2}s", elapsed.as_secs_f64());
@@ -51,42 +90,77 @@ pub fn generate(session: &Session) -> Result<()> {
     Ok(())
 }
 
-fn generate_table(table: Table, session: &Session) -> Result<()> {
+fn dat_output_tables(tables: Vec<Table>) -> Vec<Table> {
+    tables
+        .into_iter()
+        .filter(|table| table.is_main_table())
+        .collect()
+}
+
+fn tables_for_session(session: &Session) -> Vec<Table> {
+    if session.generate_only_one_table() {
+        vec![session.get_only_table_to_generate()]
+    } else {
+        Table::main_tables()
+    }
+}
+
+fn progress_totals(tables: &[Table], session: &Session) -> Vec<(Table, u64)> {
+    tables
+        .iter()
+        .filter_map(|&table| progress_total_for_table(table, session))
+        .collect()
+}
+
+fn progress_total_for_table(table: Table, session: &Session) -> Option<(Table, u64)> {
+    match table {
+        // The *_returns totals are not known up front because those rows are
+        // randomly emitted during generation of their respective parent tables.
+        Table::StoreReturns | Table::CatalogReturns | Table::WebReturns => None,
+        table => Some((table, session.get_scaling().get_row_count(table) as u64)),
+    }
+}
+
+fn generate_table(table: Table, session: &Session, progress: &RunProgress) -> Result<()> {
     match table {
         // Simple dimension tables
-        Table::CallCenter => generate_simple::<CallCenterRowGenerator>(table, session),
-        Table::CatalogPage => generate_simple::<CatalogPageRowGenerator>(table, session),
-        Table::Customer => generate_simple::<CustomerRowGenerator>(table, session),
-        Table::CustomerAddress => generate_simple::<CustomerAddressRowGenerator>(table, session),
+        Table::CallCenter => generate_simple::<CallCenterRowGenerator>(table, session, progress),
+        Table::CatalogPage => generate_simple::<CatalogPageRowGenerator>(table, session, progress),
+        Table::Customer => generate_simple::<CustomerRowGenerator>(table, session, progress),
+        Table::CustomerAddress => {
+            generate_simple::<CustomerAddressRowGenerator>(table, session, progress)
+        }
         Table::CustomerDemographics => {
-            generate_simple::<CustomerDemographicsRowGenerator>(table, session)
+            generate_simple::<CustomerDemographicsRowGenerator>(table, session, progress)
         }
-        Table::DateDim => generate_simple::<DateDimRowGenerator>(table, session),
-        Table::DbgenVersion => generate_simple::<DbgenVersionRowGenerator>(table, session),
+        Table::DateDim => generate_simple::<DateDimRowGenerator>(table, session, progress),
+        Table::DbgenVersion => {
+            generate_simple::<DbgenVersionRowGenerator>(table, session, progress)
+        }
         Table::HouseholdDemographics => {
-            generate_simple::<HouseholdDemographicsRowGenerator>(table, session)
+            generate_simple::<HouseholdDemographicsRowGenerator>(table, session, progress)
         }
-        Table::IncomeBand => generate_simple::<IncomeBandRowGenerator>(table, session),
-        Table::Item => generate_simple::<ItemRowGenerator>(table, session),
-        Table::Promotion => generate_simple::<PromotionRowGenerator>(table, session),
-        Table::Reason => generate_simple::<ReasonRowGenerator>(table, session),
-        Table::ShipMode => generate_simple::<ShipModeRowGenerator>(table, session),
-        Table::Store => generate_simple::<StoreRowGenerator>(table, session),
-        Table::TimeDim => generate_simple::<TimeDimRowGenerator>(table, session),
-        Table::Warehouse => generate_simple::<WarehouseRowGenerator>(table, session),
-        Table::WebPage => generate_simple::<WebPageRowGenerator>(table, session),
-        Table::WebSite => generate_simple::<WebSiteRowGenerator>(table, session),
+        Table::IncomeBand => generate_simple::<IncomeBandRowGenerator>(table, session, progress),
+        Table::Item => generate_simple::<ItemRowGenerator>(table, session, progress),
+        Table::Promotion => generate_simple::<PromotionRowGenerator>(table, session, progress),
+        Table::Reason => generate_simple::<ReasonRowGenerator>(table, session, progress),
+        Table::ShipMode => generate_simple::<ShipModeRowGenerator>(table, session, progress),
+        Table::Store => generate_simple::<StoreRowGenerator>(table, session, progress),
+        Table::TimeDim => generate_simple::<TimeDimRowGenerator>(table, session, progress),
+        Table::Warehouse => generate_simple::<WarehouseRowGenerator>(table, session, progress),
+        Table::WebPage => generate_simple::<WebPageRowGenerator>(table, session, progress),
+        Table::WebSite => generate_simple::<WebSiteRowGenerator>(table, session, progress),
 
         // Sales + Returns pairs
-        Table::StoreSales => generate_store_sales(session),
+        Table::StoreSales => generate_store_sales(session, progress),
         Table::StoreReturns => Ok(()), // Generated with StoreSales
-        Table::CatalogSales => generate_catalog_sales(session),
+        Table::CatalogSales => generate_catalog_sales(session, progress),
         Table::CatalogReturns => Ok(()), // Generated with CatalogSales
-        Table::WebSales => generate_web_sales(session),
+        Table::WebSales => generate_web_sales(session, progress),
         Table::WebReturns => Ok(()), // Generated with WebSales
 
         // Special tables
-        Table::Inventory => generate_inventory(session),
+        Table::Inventory => generate_inventory(session, progress),
 
         // Source tables - skip
         _ => Ok(()),
@@ -131,16 +205,24 @@ impl_factory!(
 );
 
 /// Generate a simple table (one row per row_number, no child tables)
-fn generate_simple<G: RowGeneratorFactory>(table: Table, session: &Session) -> Result<()> {
+fn generate_simple<G: RowGeneratorFactory>(
+    table: Table,
+    session: &Session,
+    progress: &RunProgress,
+) -> Result<()> {
     let mut generator = G::create();
     let row_count = session.get_scaling().get_row_count(table);
+    let show_status = !progress.is_enabled();
+    let progress = progress.for_table(table);
 
     let path = get_output_path(table, session);
     let file = File::create(&path)?;
     let mut writer = CompatWriter::new(BufWriter::new(file), session.get_compat_mode());
 
-    print!("Generating {}... ", table.get_name());
-    std::io::stdout().flush()?;
+    if show_status {
+        print!("Generating {}... ", table.get_name());
+        std::io::stdout().flush()?;
+    }
 
     for row_number in 1..=row_count {
         let result = generator.generate_row_and_child_rows(row_number, session, None, None)?;
@@ -150,18 +232,23 @@ fn generate_simple<G: RowGeneratorFactory>(table: Table, session: &Session) -> R
         }
 
         generator.consume_remaining_seeds_for_row();
+        progress.increment_output_unit();
     }
 
     writer.flush()?;
-    println!("{} rows -> {}", row_count, path.display());
+    if show_status {
+        println!("{} rows -> {}", row_count, path.display());
+    }
 
     Ok(())
 }
 
 /// Generate store_sales and store_returns together
-fn generate_store_sales(session: &Session) -> Result<()> {
+fn generate_store_sales(session: &Session, progress: &RunProgress) -> Result<()> {
     let mut generator = StoreSalesRowGenerator::new();
     let num_orders = session.get_scaling().get_row_count(Table::StoreSales);
+    let show_status = !progress.is_enabled();
+    let progress = progress.for_table(Table::StoreSales);
 
     let sales_path = get_output_path(Table::StoreSales, session);
     let returns_path = get_output_path(Table::StoreReturns, session);
@@ -172,8 +259,10 @@ fn generate_store_sales(session: &Session) -> Result<()> {
     let mut returns_writer =
         CompatWriter::new(BufWriter::new(File::create(&returns_path)?), compat_mode);
 
-    print!("Generating store_sales + store_returns... ");
-    std::io::stdout().flush()?;
+    if show_status {
+        print!("Generating store_sales + store_returns... ");
+        std::io::stdout().flush()?;
+    }
 
     let mut sales_count = 0i64;
     let mut returns_count = 0i64;
@@ -196,27 +285,32 @@ fn generate_store_sales(session: &Session) -> Result<()> {
         if result.should_end_row() {
             generator.consume_remaining_seeds_for_row();
             row_number += 1;
+            progress.increment_output_unit();
         }
     }
 
     sales_writer.flush()?;
     returns_writer.flush()?;
 
-    println!(
-        "{} sales, {} returns -> {}, {}",
-        sales_count,
-        returns_count,
-        sales_path.display(),
-        returns_path.display()
-    );
+    if show_status {
+        println!(
+            "{} sales, {} returns -> {}, {}",
+            sales_count,
+            returns_count,
+            sales_path.display(),
+            returns_path.display()
+        );
+    }
 
     Ok(())
 }
 
 /// Generate catalog_sales and catalog_returns together
-fn generate_catalog_sales(session: &Session) -> Result<()> {
+fn generate_catalog_sales(session: &Session, progress: &RunProgress) -> Result<()> {
     let mut generator = CatalogSalesRowGenerator::new();
     let num_orders = session.get_scaling().get_row_count(Table::CatalogSales);
+    let show_status = !progress.is_enabled();
+    let progress = progress.for_table(Table::CatalogSales);
 
     let sales_path = get_output_path(Table::CatalogSales, session);
     let returns_path = get_output_path(Table::CatalogReturns, session);
@@ -227,8 +321,10 @@ fn generate_catalog_sales(session: &Session) -> Result<()> {
     let mut returns_writer =
         CompatWriter::new(BufWriter::new(File::create(&returns_path)?), compat_mode);
 
-    print!("Generating catalog_sales + catalog_returns... ");
-    std::io::stdout().flush()?;
+    if show_status {
+        print!("Generating catalog_sales + catalog_returns... ");
+        std::io::stdout().flush()?;
+    }
 
     let mut sales_count = 0i64;
     let mut returns_count = 0i64;
@@ -251,27 +347,32 @@ fn generate_catalog_sales(session: &Session) -> Result<()> {
         if result.should_end_row() {
             generator.consume_remaining_seeds_for_row();
             row_number += 1;
+            progress.increment_output_unit();
         }
     }
 
     sales_writer.flush()?;
     returns_writer.flush()?;
 
-    println!(
-        "{} sales, {} returns -> {}, {}",
-        sales_count,
-        returns_count,
-        sales_path.display(),
-        returns_path.display()
-    );
+    if show_status {
+        println!(
+            "{} sales, {} returns -> {}, {}",
+            sales_count,
+            returns_count,
+            sales_path.display(),
+            returns_path.display()
+        );
+    }
 
     Ok(())
 }
 
 /// Generate web_sales and web_returns together
-fn generate_web_sales(session: &Session) -> Result<()> {
+fn generate_web_sales(session: &Session, progress: &RunProgress) -> Result<()> {
     let mut generator = WebSalesRowGenerator::new();
     let num_orders = session.get_scaling().get_row_count(Table::WebSales);
+    let show_status = !progress.is_enabled();
+    let progress = progress.for_table(Table::WebSales);
 
     let sales_path = get_output_path(Table::WebSales, session);
     let returns_path = get_output_path(Table::WebReturns, session);
@@ -282,8 +383,10 @@ fn generate_web_sales(session: &Session) -> Result<()> {
     let mut returns_writer =
         CompatWriter::new(BufWriter::new(File::create(&returns_path)?), compat_mode);
 
-    print!("Generating web_sales + web_returns... ");
-    std::io::stdout().flush()?;
+    if show_status {
+        print!("Generating web_sales + web_returns... ");
+        std::io::stdout().flush()?;
+    }
 
     let mut sales_count = 0i64;
     let mut returns_count = 0i64;
@@ -306,33 +409,32 @@ fn generate_web_sales(session: &Session) -> Result<()> {
         if result.should_end_row() {
             generator.consume_remaining_seeds_for_row();
             row_number += 1;
+            progress.increment_output_unit();
         }
     }
 
     sales_writer.flush()?;
     returns_writer.flush()?;
 
-    println!(
-        "{} sales, {} returns -> {}, {}",
-        sales_count,
-        returns_count,
-        sales_path.display(),
-        returns_path.display()
-    );
+    if show_status {
+        println!(
+            "{} sales, {} returns -> {}, {}",
+            sales_count,
+            returns_count,
+            sales_path.display(),
+            returns_path.display()
+        );
+    }
 
     Ok(())
 }
 
-/// Generate inventory table (special row count calculation)
-fn generate_inventory(session: &Session) -> Result<()> {
+/// Generate inventory table.
+fn generate_inventory(session: &Session, progress: &RunProgress) -> Result<()> {
     let mut generator = InventoryRowGenerator::new();
-    let scaling = session.get_scaling();
-
-    let item_count = scaling.get_id_count(Table::Item);
-    let warehouse_count = scaling.get_row_count(Table::Warehouse);
-    let n_days = Date::JULIAN_DATE_MAXIMUM - Date::JULIAN_DATE_MINIMUM;
-    let n_weeks = (n_days + 7) / 7;
-    let num_rows = item_count * warehouse_count * n_weeks as i64;
+    let num_rows = session.get_scaling().get_row_count(Table::Inventory);
+    let show_status = !progress.is_enabled();
+    let progress = progress.for_table(Table::Inventory);
 
     let path = get_output_path(Table::Inventory, session);
     let mut writer = CompatWriter::new(
@@ -340,8 +442,10 @@ fn generate_inventory(session: &Session) -> Result<()> {
         session.get_compat_mode(),
     );
 
-    print!("Generating inventory... ");
-    std::io::stdout().flush()?;
+    if show_status {
+        print!("Generating inventory... ");
+        std::io::stdout().flush()?;
+    }
 
     for row_number in 1..=num_rows {
         let result = generator.generate_row_and_child_rows(row_number, session, None, None)?;
@@ -351,10 +455,13 @@ fn generate_inventory(session: &Session) -> Result<()> {
         }
 
         generator.consume_remaining_seeds_for_row();
+        progress.increment_output_unit();
     }
 
     writer.flush()?;
-    println!("{} rows -> {}", num_rows, path.display());
+    if show_status {
+        println!("{} rows -> {}", num_rows, path.display());
+    }
 
     Ok(())
 }
@@ -366,4 +473,182 @@ fn get_output_path(table: Table, session: &Session) -> std::path::PathBuf {
         table.get_name(),
         session.get_suffix()
     ))
+}
+
+#[cfg(all(test, feature = "progress"))]
+mod tests {
+    use super::*;
+    use crate::config::Options;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum ProgressEvent {
+        Register(Table, u64),
+        Increment(Table, u64),
+        Finish,
+    }
+
+    #[derive(Debug, Default)]
+    struct CountingProgress {
+        registered: Mutex<Vec<(Table, u64)>>,
+        increments: Mutex<HashMap<Table, u64>>,
+        events: Mutex<Vec<ProgressEvent>>,
+        finishes: AtomicUsize,
+    }
+
+    impl ProgressTracker for CountingProgress {
+        fn register(&self, table: Table, total_units: u64) {
+            self.events
+                .lock()
+                .expect("events lock")
+                .push(ProgressEvent::Register(table, total_units));
+            self.registered
+                .lock()
+                .expect("registered lock")
+                .push((table, total_units));
+        }
+
+        fn increment(&self, table: Table, units: u64) {
+            self.events
+                .lock()
+                .expect("events lock")
+                .push(ProgressEvent::Increment(table, units));
+            *self
+                .increments
+                .lock()
+                .expect("increments lock")
+                .entry(table)
+                .or_default() += units;
+        }
+
+        fn finish(&self) {
+            self.events
+                .lock()
+                .expect("events lock")
+                .push(ProgressEvent::Finish);
+            self.finishes.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn generate_with_progress_reports_reason_rows() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+
+        let mut options = Options::new();
+        options.directory = temp_dir.path().to_string_lossy().into_owned();
+        options.table = Some("reason".to_string());
+        let session = options.to_session().expect("session");
+
+        let tracker = Arc::new(CountingProgress::default());
+        let progress: Arc<dyn ProgressTracker> = tracker.clone();
+        generate_with_progress(&session, progress).expect("generate");
+
+        assert_eq!(
+            tracker
+                .registered
+                .lock()
+                .expect("registered lock")
+                .as_slice(),
+            &[(Table::Reason, 35)]
+        );
+        assert_eq!(
+            tracker
+                .increments
+                .lock()
+                .expect("increments lock")
+                .get(&Table::Reason),
+            Some(&35)
+        );
+        assert_eq!(tracker.finishes.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn generate_tables_with_progress_registers_all_tables_before_incrementing() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+
+        let mut options = Options::new();
+        options.directory = temp_dir.path().to_string_lossy().into_owned();
+        let session = options.to_session().expect("session");
+
+        let tracker = Arc::new(CountingProgress::default());
+        let progress: Arc<dyn ProgressTracker> = tracker.clone();
+        generate_tables_with_progress(&session, &[Table::Reason, Table::ShipMode], progress)
+            .expect("generate");
+
+        let events = tracker.events.lock().expect("events lock");
+        assert_eq!(
+            &events[..2],
+            &[
+                ProgressEvent::Register(Table::Reason, 35),
+                ProgressEvent::Register(Table::ShipMode, 20)
+            ]
+        );
+        assert!(matches!(
+            events[2],
+            ProgressEvent::Increment(Table::Reason, 1)
+        ));
+    }
+
+    #[test]
+    fn generate_tables_with_progress_does_not_register_source_tables() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+
+        let mut options = Options::new();
+        options.directory = temp_dir.path().to_string_lossy().into_owned();
+        let session = options.to_session().expect("session");
+
+        let tracker = Arc::new(CountingProgress::default());
+        let progress: Arc<dyn ProgressTracker> = tracker.clone();
+        generate_tables_with_progress(&session, &[Table::SBrand], progress).expect("generate");
+
+        assert!(tracker
+            .registered
+            .lock()
+            .expect("registered lock")
+            .is_empty());
+        assert!(tracker
+            .increments
+            .lock()
+            .expect("increments lock")
+            .is_empty());
+        assert_eq!(tracker.finishes.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn generate_tables_with_progress_matches_registered_totals() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+
+        let mut options = Options::new();
+        options.directory = temp_dir.path().to_string_lossy().into_owned();
+        options.scale = 0.001;
+        let session = options.to_session().expect("session");
+
+        let tables = [
+            Table::Reason,
+            Table::ShipMode,
+            Table::StoreSales,
+            Table::CatalogSales,
+            Table::WebSales,
+            Table::Inventory,
+        ];
+        let tracker = Arc::new(CountingProgress::default());
+        let progress: Arc<dyn ProgressTracker> = tracker.clone();
+        generate_tables_with_progress(&session, &tables, progress).expect("generate");
+
+        let registered = tracker.registered.lock().expect("registered lock");
+        let increments = tracker.increments.lock().expect("increments lock");
+        assert!(
+            !registered.is_empty(),
+            "expected representative tables to register progress totals"
+        );
+        for (table, total) in registered.iter().copied() {
+            assert_eq!(
+                increments.get(&table).copied(),
+                Some(total),
+                "expected {table} increments to match the registered total"
+            );
+        }
+    }
 }

--- a/tpcdsgen/src/lib.rs
+++ b/tpcdsgen/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod business_key_generator;
 pub mod column;
 pub mod config;
+pub mod dat;
 pub mod distribution;
 pub mod error;
 pub mod generator;

--- a/tpcdsgen/src/lib.rs
+++ b/tpcdsgen/src/lib.rs
@@ -9,6 +9,10 @@ pub mod join_key_utils;
 pub mod nulls;
 pub mod output;
 pub mod permutations;
+#[cfg(not(feature = "progress"))]
+mod progress;
+#[cfg(feature = "progress")]
+pub mod progress;
 pub mod pseudo_table_scaling_infos;
 pub mod random;
 pub mod row;

--- a/tpcdsgen/src/main.rs
+++ b/tpcdsgen/src/main.rs
@@ -1,0 +1,10 @@
+use clap::Parser;
+use tpcdsgen::config::Options;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+fn main() -> Result<()> {
+    let options = Options::parse();
+    let session = options.to_session()?;
+    tpcdsgen::dat::generate(&session)
+}

--- a/tpcdsgen/src/progress.rs
+++ b/tpcdsgen/src/progress.rs
@@ -1,0 +1,266 @@
+//! Progress tracking for TPC-DS data generation.
+
+use crate::config::Table;
+#[cfg(feature = "progress")]
+use std::fmt;
+#[cfg(feature = "progress")]
+use std::sync::Arc;
+
+/// Receives generation-progress events for one DAT generation invocation.
+///
+/// See the [module-level documentation](self) for the call-order contract.
+/// Trackers are passed as an [`std::sync::Arc`] so they must be `Send + Sync`.
+/// They must also be `Debug` so containing types can derive `Debug`.
+#[cfg(feature = "progress")]
+pub trait ProgressTracker: Send + Sync + fmt::Debug {
+    /// Pre-register a table with its total expected output-unit count.
+    ///
+    /// Called once per table before generation starts. Implementations that
+    /// need to know totals up front, such as progress bars or ETA trackers,
+    /// should override this; the default does nothing.
+    fn register(&self, _table: Table, _total_units: u64) {}
+
+    /// Advance the counter for `table` by `units` output units.
+    ///
+    /// Called after generated output units are written.
+    fn increment(&self, table: Table, units: u64);
+
+    /// Called once after the last [`Self::increment`] on the success path.
+    fn finish(&self) {}
+}
+
+/// Progress handle for one DAT generation invocation.
+///
+/// Owns run-level progress lifecycle: registering totals and finishing the
+/// tracker.
+#[derive(Debug, Clone, Default)]
+#[cfg(feature = "progress")]
+pub(crate) struct RunProgress {
+    tracker: Option<Arc<dyn ProgressTracker>>,
+}
+
+#[cfg(feature = "progress")]
+impl RunProgress {
+    pub(crate) fn with_tracker(tracker: Arc<dyn ProgressTracker>) -> Self {
+        Self {
+            tracker: Some(tracker),
+        }
+    }
+
+    pub(crate) fn register_totals(&self, totals: &[(Table, u64)]) {
+        if let Some(tracker) = self.tracker.as_ref() {
+            for (table, total_units) in totals {
+                tracker.register(*table, *total_units);
+            }
+        }
+    }
+
+    pub(crate) fn for_table(&self, table: Table) -> TableProgress {
+        TableProgress::for_table(self.tracker.clone(), table)
+    }
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.tracker.is_some()
+    }
+
+    pub(crate) fn finish(self) {
+        if let Some(tracker) = self.tracker {
+            tracker.finish();
+        }
+    }
+}
+
+/// No-op run progress handle used when progress support is disabled.
+#[derive(Debug, Clone, Default)]
+#[cfg(not(feature = "progress"))]
+pub(crate) struct RunProgress;
+
+#[cfg(not(feature = "progress"))]
+impl RunProgress {
+    pub(crate) fn register_totals(&self, _totals: &[(Table, u64)]) {}
+
+    pub(crate) fn for_table(&self, _table: Table) -> TableProgress {
+        TableProgress
+    }
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        false
+    }
+
+    pub(crate) fn finish(self) {}
+}
+
+/// Progress handle for one table output stream.
+///
+/// Used by DAT output loops to report each successfully written output unit
+/// without knowing whether progress tracking is enabled.
+#[derive(Clone, Default)]
+#[cfg(feature = "progress")]
+pub(crate) struct TableProgress {
+    tracker: Option<(Arc<dyn ProgressTracker>, Table)>,
+}
+
+#[cfg(feature = "progress")]
+impl TableProgress {
+    pub(crate) fn for_table(progress: Option<Arc<dyn ProgressTracker>>, table: Table) -> Self {
+        Self {
+            tracker: progress.map(|progress| (progress, table)),
+        }
+    }
+
+    pub(crate) fn increment_output_unit(&self) {
+        if let Some((progress, table)) = self.tracker.as_ref() {
+            progress.increment(*table, 1);
+        }
+    }
+}
+
+/// No-op table progress handle used when progress support is disabled.
+#[derive(Clone, Default)]
+#[cfg(not(feature = "progress"))]
+pub(crate) struct TableProgress;
+
+#[cfg(not(feature = "progress"))]
+impl TableProgress {
+    pub(crate) fn increment_output_unit(&self) {}
+}
+
+#[cfg(feature = "indicatif-progress")]
+pub use indicatif_impl::IndicatifProgress;
+
+#[cfg(feature = "indicatif-progress")]
+mod indicatif_impl {
+    use super::ProgressTracker;
+    use crate::config::Table;
+    use indicatif::{MultiProgress, ProgressBar, ProgressFinish, ProgressStyle};
+    use std::collections::HashMap;
+    use std::io::{self, Write};
+    use std::sync::{OnceLock, RwLock};
+
+    // Pad table names to the longest TPC-DS main table, `household_demographics`,
+    // so every bar starts in the same column. The test below catches future drift.
+    const TABLE_NAME_WIDTH: usize = 22;
+    const PROGRESS_BAR_WIDTH: usize = 28;
+
+    /// Default [`ProgressTracker`] implementation backed by
+    /// [`indicatif::MultiProgress`].
+    ///
+    /// Renders one bar per table on stderr. Bars are pre-allocated in
+    /// [`ProgressTracker::register`] and are looked up by [`Table`] on each
+    /// [`ProgressTracker::increment`] call.
+    #[derive(Debug)]
+    pub struct IndicatifProgress {
+        multi: MultiProgress,
+        tables: RwLock<HashMap<Table, ProgressBar>>,
+    }
+
+    impl IndicatifProgress {
+        /// Construct an empty tracker. Tables are added via
+        /// [`ProgressTracker::register`].
+        pub fn new() -> Self {
+            Self {
+                multi: MultiProgress::new(),
+                tables: RwLock::new(HashMap::new()),
+            }
+        }
+
+        /// Return a writer that coordinates stderr log writes with progress
+        /// bar redraws.
+        pub fn log_writer(&self) -> Box<dyn io::Write + Send + 'static> {
+            Box::new(IndicatifLogWriter {
+                multi: self.multi.clone(),
+            })
+        }
+    }
+
+    impl Default for IndicatifProgress {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl ProgressTracker for IndicatifProgress {
+        fn register(&self, table: Table, total_units: u64) {
+            let Ok(mut tables) = self.tables.write() else {
+                return;
+            };
+
+            let pb = self.multi.add(ProgressBar::new(total_units));
+            pb.set_style(bar_style().clone());
+            pb.set_message(table.to_string());
+            let pb = pb.with_finish(ProgressFinish::AndLeave);
+            tables.insert(table, pb);
+        }
+
+        fn increment(&self, table: Table, units: u64) {
+            let bar = {
+                let Ok(tables) = self.tables.read() else {
+                    return;
+                };
+                tables.get(&table).cloned()
+            };
+            if let Some(bar) = bar {
+                bar.inc(units);
+                if bar.length().is_some_and(|length| bar.position() >= length) {
+                    bar.finish_using_style();
+                }
+            }
+        }
+
+        fn finish(&self) {
+            let bars = {
+                let Ok(tables) = self.tables.read() else {
+                    return;
+                };
+                tables.values().cloned().collect::<Vec<_>>()
+            };
+            for bar in bars {
+                bar.finish_using_style();
+            }
+        }
+    }
+
+    fn bar_style() -> &'static ProgressStyle {
+        static STYLE: OnceLock<ProgressStyle> = OnceLock::new();
+        STYLE.get_or_init(|| {
+            let template = format!(
+                "{{msg:{TABLE_NAME_WIDTH}}} [{{bar:{PROGRESS_BAR_WIDTH}}}]   Progress: {{percent:>3}}%"
+            );
+
+            ProgressStyle::default_bar()
+                .template(&template)
+                .expect("static progress bar template is valid")
+                .progress_chars("█▓░")
+        })
+    }
+
+    struct IndicatifLogWriter {
+        multi: MultiProgress,
+    }
+
+    impl Write for IndicatifLogWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.multi.suspend(|| io::stderr().write(buf))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.multi.suspend(|| io::stderr().flush())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn table_name_width_covers_main_tables() {
+            let max_table_name_width = Table::main_tables()
+                .into_iter()
+                .map(|table| table.to_string().len())
+                .max()
+                .expect("TPC-DS has main tables");
+
+            assert_eq!(max_table_name_width, TABLE_NAME_WIDTH);
+        }
+    }
+}

--- a/tpcgen/Cargo.toml
+++ b/tpcgen/Cargo.toml
@@ -19,6 +19,7 @@ path = "bin/tpcgen.rs"
 
 [dependencies]
 clap = { version = "4.5.32", features = ["derive"] }
+tpcdsgen = { path = "../tpcdsgen", version = "0.1.0" }
 tokio = { version = "1.44.1", features = ["full"] }
 tpchgen-cli = { path = "../tpchgen-cli", version = "2.0.2", default-features = false, features = ["indicatif-progress"] }
 

--- a/tpcgen/Cargo.toml
+++ b/tpcgen/Cargo.toml
@@ -19,7 +19,9 @@ path = "bin/tpcgen.rs"
 
 [dependencies]
 clap = { version = "4.5.32", features = ["derive"] }
-tpcdsgen = { path = "../tpcdsgen", version = "0.1.0" }
+env_logger = "0.11.7"
+log = "0.4.27"
+tpcdsgen = { path = "../tpcdsgen", version = "0.1.0", features = ["indicatif-progress"] }
 tokio = { version = "1.44.1", features = ["full"] }
 tpchgen-cli = { path = "../tpchgen-cli", version = "2.0.2", default-features = false, features = ["indicatif-progress"] }
 

--- a/tpcgen/src/tpcds_cli.rs
+++ b/tpcgen/src/tpcds_cli.rs
@@ -1,7 +1,11 @@
 use clap::{ArgAction, Args, Subcommand};
+use log::{info, LevelFilter};
 use std::fmt;
+use std::io::{self, IsTerminal};
 use std::path::PathBuf;
-use tpcdsgen::config::{CompatMode, Options as TpcdsOptions};
+use std::sync::Arc;
+use tpcdsgen::config::{CompatMode, Options as TpcdsOptions, Table as TpcdsTable};
+use tpcdsgen::progress::{IndicatifProgress, ProgressTracker};
 use tpchgen_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -183,21 +187,56 @@ impl ParquetArgs {
 
 impl CommonArgs {
     fn run_dat(self) -> Result<()> {
-        if let Some(tables) = &self.tables {
-            for table in tables {
-                self.run_dat_for_table(Some(table.clone()))?;
-            }
-        } else {
-            self.run_dat_for_table(None)?;
-        }
+        let progress = self.progress_tracker();
+        configure_logging(
+            self.verbose,
+            self.quiet,
+            progress.as_ref().map(|progress| progress.log_writer()),
+        );
+        let progress = progress.map(|progress| progress as Arc<dyn ProgressTracker>);
+        let options = self.to_tpcds_options(None);
+        let session = options.to_session()?;
 
-        Ok(())
+        if let Some(tables) = &self.tables {
+            let tables = parse_tables(tables)?;
+            self.run_dat_for_tables(&session, &tables, progress)
+        } else {
+            self.run_dat_for_session(&session, progress)
+        }
     }
 
-    fn run_dat_for_table(&self, table: Option<String>) -> Result<()> {
-        let options = self.to_tpcds_options(table);
-        let session = options.to_session()?;
-        tpcdsgen::dat::generate(&session)
+    fn run_dat_for_session(
+        &self,
+        session: &tpcdsgen::config::Session,
+        progress: Option<Arc<dyn ProgressTracker>>,
+    ) -> Result<()> {
+        if let Some(progress) = progress {
+            tpcdsgen::dat::generate_with_progress(session, progress)
+        } else {
+            tpcdsgen::dat::generate(session)
+        }
+    }
+
+    fn run_dat_for_tables(
+        &self,
+        session: &tpcdsgen::config::Session,
+        tables: &[TpcdsTable],
+        progress: Option<Arc<dyn ProgressTracker>>,
+    ) -> Result<()> {
+        if let Some(progress) = progress {
+            tpcdsgen::dat::generate_tables_with_progress(session, tables, progress)
+        } else {
+            tpcdsgen::dat::generate_tables(session, tables)
+        }
+    }
+
+    fn progress_tracker(&self) -> Option<Arc<IndicatifProgress>> {
+        self.should_show_progress_bars()
+            .then(|| Arc::new(IndicatifProgress::new()))
+    }
+
+    fn should_show_progress_bars(&self) -> bool {
+        self.progress_bars_enabled && !self.quiet && io::stderr().is_terminal()
     }
 
     fn to_tpcds_options(&self, table: Option<String>) -> TpcdsOptions {
@@ -219,6 +258,37 @@ impl CommonArgs {
     fn run_not_implemented(self) -> Result<()> {
         let _ = self;
         Err(Box::new(NotImplemented))
+    }
+}
+
+fn parse_tables(tables: &[String]) -> Result<Vec<TpcdsTable>> {
+    tables
+        .iter()
+        .map(|table| table.parse::<TpcdsTable>().map_err(Into::into))
+        .collect()
+}
+
+fn configure_logging(
+    verbose: bool,
+    quiet: bool,
+    log_writer: Option<Box<dyn io::Write + Send + 'static>>,
+) {
+    let mut builder = env_logger::builder();
+    if quiet {
+        builder.filter_level(LevelFilter::Error);
+    } else if verbose {
+        builder.filter_level(LevelFilter::Info);
+    } else {
+        builder.filter_level(LevelFilter::Warn).parse_default_env();
+    }
+    if let Some(log_writer) = log_writer {
+        builder.target(env_logger::Target::Pipe(log_writer));
+    }
+
+    let _ = builder.try_init();
+
+    if verbose {
+        info!("Verbose output enabled (ignoring RUST_LOG environment variable)");
     }
 }
 

--- a/tpcgen/src/tpcds_cli.rs
+++ b/tpcgen/src/tpcds_cli.rs
@@ -1,6 +1,7 @@
 use clap::{ArgAction, Args, Subcommand};
 use std::fmt;
 use std::path::PathBuf;
+use tpcdsgen::config::{CompatMode, Options as TpcdsOptions};
 use tpchgen_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -99,6 +100,38 @@ struct CommonArgs {
     #[arg(short = 'T', long = "tables", value_delimiter = ',')]
     tables: Option<Vec<String>>,
 
+    /// Suffix for generated data files
+    #[arg(long = "suffix", default_value = TpcdsOptions::DEFAULT_SUFFIX)]
+    suffix: String,
+
+    /// String representation for null values
+    #[arg(long = "null", default_value = TpcdsOptions::DEFAULT_NULL_STRING)]
+    null_string: String,
+
+    /// Separator between columns
+    #[arg(long = "separator", default_value = "|")]
+    separator: String,
+
+    /// Do not terminate each row with a separator
+    #[arg(long = "do-not-terminate")]
+    do_not_terminate: bool,
+
+    /// Use gender-neutral manager names
+    #[arg(long = "no-sexism")]
+    no_sexism: bool,
+
+    /// Build data in `n` separate chunks
+    #[arg(long = "parallelism", default_value_t = TpcdsOptions::DEFAULT_PARALLELISM)]
+    parallelism: i32,
+
+    /// Overwrite existing data files for tables
+    #[arg(long = "overwrite")]
+    overwrite: bool,
+
+    /// Reference implementation to match
+    #[arg(long = "compat", default_value = "trino")]
+    compat: CompatMode,
+
     /// Verbose output
     ///
     /// When specified, sets the log level to `info` and ignores the `RUST_LOG`
@@ -130,34 +163,61 @@ impl Cli {
 
 impl DatArgs {
     fn run(self) -> Result<()> {
-        self.common.run()
+        self.common.run_dat()
     }
 }
 
 impl CsvArgs {
     fn run(self) -> Result<()> {
         let _ = self.delimiter;
-        self.common.run()
+        self.common.run_not_implemented()
     }
 }
 
 impl ParquetArgs {
     fn run(self) -> Result<()> {
         let _ = (self.compression, self.row_group_bytes);
-        self.common.run()
+        self.common.run_not_implemented()
     }
 }
 
 impl CommonArgs {
-    fn run(self) -> Result<()> {
-        let _ = (
-            self.scale_factor,
-            self.output_dir,
-            self.tables,
-            self.verbose,
-            self.quiet,
-            self.progress_bars_enabled,
-        );
+    fn run_dat(self) -> Result<()> {
+        if let Some(tables) = &self.tables {
+            for table in tables {
+                self.run_dat_for_table(Some(table.clone()))?;
+            }
+        } else {
+            self.run_dat_for_table(None)?;
+        }
+
+        Ok(())
+    }
+
+    fn run_dat_for_table(&self, table: Option<String>) -> Result<()> {
+        let options = self.to_tpcds_options(table);
+        let session = options.to_session()?;
+        tpcdsgen::dat::generate(&session)
+    }
+
+    fn to_tpcds_options(&self, table: Option<String>) -> TpcdsOptions {
+        let mut options = TpcdsOptions::new();
+        options.scale = self.scale_factor;
+        options.directory = self.output_dir.to_string_lossy().into_owned();
+        options.suffix = self.suffix.clone();
+        options.table = table;
+        options.null_string = self.null_string.clone();
+        options.separator = self.separator.clone();
+        options.do_not_terminate = self.do_not_terminate;
+        options.no_sexism = self.no_sexism;
+        options.parallelism = self.parallelism;
+        options.overwrite = self.overwrite;
+        options.compat = self.compat;
+        options
+    }
+
+    fn run_not_implemented(self) -> Result<()> {
+        let _ = self;
         Err(Box::new(NotImplemented))
     }
 }

--- a/tpcgen/tests/cli_integration.rs
+++ b/tpcgen/tests/cli_integration.rs
@@ -122,6 +122,58 @@ fn test_tpcgen_tpcds_dat_options() {
     );
 }
 
+/// Test that TPC-DS progress bars are auto-suppressed when stderr is not a TTY.
+#[test]
+fn test_tpcgen_tpcds_progress_auto_disabled_on_non_tty() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    let output = cargo_bin_cmd!("tpcgen")
+        .arg("tpcds")
+        .arg("dat")
+        .arg("--scale-factor")
+        .arg("1")
+        .arg("--tables")
+        .arg("reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .assert()
+        .success();
+
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    for glyph in ["█", "▓", "░", "Progress:"] {
+        assert!(
+            !stderr.contains(glyph),
+            "Expected progress to be auto-disabled on non-TTY stderr, but found {glyph:?} in: {stderr}"
+        );
+    }
+}
+
+/// Test that TPC-DS configures logging for the unified `tpcgen` binary.
+#[test]
+fn test_tpcgen_tpcds_verbose_configures_logging() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    let output = cargo_bin_cmd!("tpcgen")
+        .arg("tpcds")
+        .arg("dat")
+        .arg("--scale-factor")
+        .arg("1")
+        .arg("--tables")
+        .arg("reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--verbose")
+        .arg("--no-progress")
+        .assert()
+        .success();
+
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(
+        stderr.contains("Verbose output enabled"),
+        "Expected verbose TPC-DS generation to initialize logging, got stderr: {stderr}"
+    );
+}
+
 /// Test that non-DAT TPC-DS command forms still report that generation is unavailable.
 #[test]
 fn test_tpcgen_tpcds_non_dat_command_forms_are_not_implemented() {

--- a/tpcgen/tests/cli_integration.rs
+++ b/tpcgen/tests/cli_integration.rs
@@ -1,4 +1,5 @@
 use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs;
 use tempfile::tempdir;
 
 /// Test the TPC-H command forms for the `tpcgen` binary.
@@ -41,12 +42,90 @@ fn test_tpcgen_tpch_command_forms() {
     }
 }
 
-/// Test the TPC-DS command forms parse and report that generation is unavailable.
+/// Test the TPC-DS DAT command forms for the `tpcgen` binary.
 #[test]
-fn test_tpcgen_tpcds_command_forms_are_not_implemented() {
+fn test_tpcgen_tpcds_dat_command_forms() {
+    let forms: &[(&[&str], &str)] = &[
+        (&["tpcds"], "reason.dat"),
+        (&["tpcds", "dat"], "reason.dat"),
+    ];
+
+    for (form, expected_file) in forms {
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+        let output_dir = temp_dir.path().join("generated");
+
+        cargo_bin_cmd!("tpcgen")
+            .args(*form)
+            .arg("--scale-factor")
+            .arg("1")
+            .arg("--tables")
+            .arg("reason")
+            .arg("--output-dir")
+            .arg(&output_dir)
+            .arg("--no-progress")
+            .assert()
+            .success();
+
+        let expected_file = output_dir.join(expected_file);
+        assert!(
+            expected_file.exists(),
+            "Expected file {:?} to exist with `tpcgen {}`",
+            expected_file,
+            form.join(" ")
+        );
+
+        let contents = fs::read_to_string(&expected_file).expect("Failed to read DAT file");
+        assert!(
+            contents.starts_with("1|AAAAAAAABAAAAAAA|Package was damaged|\n"),
+            "Expected {:?} to contain deterministic pipe-delimited DAT output",
+            expected_file
+        );
+        assert_eq!(
+            contents.lines().count(),
+            35,
+            "Expected {:?} to contain the reason table at scale factor 1",
+            expected_file
+        );
+    }
+}
+
+/// Test that TPC-DS DAT generation honors native TPC-DS options.
+#[test]
+fn test_tpcgen_tpcds_dat_options() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    cargo_bin_cmd!("tpcgen")
+        .arg("tpcds")
+        .arg("dat")
+        .arg("--scale-factor")
+        .arg("1")
+        .arg("--tables")
+        .arg("reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--suffix")
+        .arg(".txt")
+        .arg("--separator")
+        .arg(",")
+        .arg("--compat")
+        .arg("trino")
+        .arg("--no-progress")
+        .assert()
+        .success();
+
+    let expected_file = temp_dir.path().join("reason.txt");
+    let contents = fs::read_to_string(&expected_file).expect("Failed to read DAT file");
+    assert!(
+        contents.starts_with("1,AAAAAAAABAAAAAAA,Package was damaged,"),
+        "Expected {:?} to honor custom suffix and separator",
+        expected_file
+    );
+}
+
+/// Test that non-DAT TPC-DS command forms still report that generation is unavailable.
+#[test]
+fn test_tpcgen_tpcds_non_dat_command_forms_are_not_implemented() {
     let forms: &[(&[&str], &[&str], &str)] = &[
-        (&["tpcds"], &[], "reason.dat"),
-        (&["tpcds", "dat"], &[], "reason.dat"),
         (&["tpcds", "csv"], &["--delimiter", "|"], "reason.csv"),
         (
             &["tpcds", "parquet"],


### PR DESCRIPTION
## Summary

Adds progress tracking for `tpcgen tpcds dat`, mirroring the `tpchgen-cli` progress architecture while keeping the TPC-DS library progress support optional.

## What Changed

- Adds a `tpcdsgen::progress` module with `ProgressTracker`, run/table progress handles, and an `indicatif` backend.
- Wires `tpcgen tpcds dat` to use progress bars only on interactive stderr, with `--no-progress` and `--quiet` suppression.
- Pre-registers selected TPC-DS tables before generation starts so all bars appear up front.
- Does not create separate progress bars for the `*_returns` tables because return rows are randomly selected during generation of their respective parent tables, and the resulting totals are not known up front for percentage progress.
- Routes TPC-DS CLI logging through the progress-aware writer when bars are active.
- Fixes completed table redraws and aligns progress-bar columns for long table names like `household_demographics`.
- Adds unit and integration coverage for registration order, total/increment accounting, non-TTY suppression, and verbose logging.

## Stack

This PR is intentionally stacked on top of `kevinjqliu/codex-tpcgen-tpcds-dat` so reviewers can inspect only the progress-tracker follow-up separately from the TPC-DS DAT CLI wiring.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --offline -p tpcdsgen`
- `cargo test --offline -p tpcdsgen --features progress progress -- --nocapture`
- `cargo test --offline -p tpcdsgen --features indicatif-progress progress -- --nocapture`
- `cargo test --offline -p tpcgen`
- `cargo clippy --offline -p tpcdsgen --features indicatif-progress --lib -- -D warnings`
- `cargo clippy --offline -p tpcgen --bin tpcgen -- -D warnings`
- pseudo-TTY smoke tests for visible progress, logging coexistence, completed-bar redraw, and long table-name alignment
